### PR TITLE
Fix uninitialized read in juniper_parse_header

### DIFF
--- a/argus/ArgusSource.c
+++ b/argus/ArgusSource.c
@@ -2414,7 +2414,7 @@ juniper_parse_header (const u_char *p, const struct pcap_pkthdr *h, struct junip
     l2info->header_len = 0;
     l2info->cookie_len = 0;
     l2info->proto = 0;
-
+    l2info->pictype = 0;
 
     l2info->length = h->len;
     l2info->caplen = h->caplen;


### PR DESCRIPTION
The `pictype` field is never initialized by the only caller of `juniper_parse_header`
(which is `ArgusJuniperPacket`). The function however reads the uninitialized
field several times, for example in the big switch statement in line 2547:

```
/* DLT_ specific parsing */
    switch(l2info->pictype) {
```

This patch just initializes the field to 0. The code in that switch and the
other code that reads this value is now effectively dead, so there is probably
a bigger bug here (but this patch is at least fixing the sanitizer failure).