### PR TITLE
fix build issues on Ubuntu 22.04

### DIFF
--- a/argus/Makefile.in
+++ b/argus/Makefile.in
@@ -85,7 +85,7 @@ PROG =	@INSTALL_BIN@/argus
 
 OBJ =	$(SRC:.c=.o)
 
-LIB = @LIBS@ @V_THREADS@ $(WRAPLIBS) $(SASLLIBS) $(XDRLIBS) $(COMPATLIB) ../lib/argus_common.a -lm
+LIB = @LIBS@ @V_THREADS@ $(WRAPLIBS) $(SASLLIBS) $(COMPATLIB) ../lib/argus_common.a -lm $(XDRLIBS)
 
 HDR =	pcap.h pcap-int.h pcap-namedb.h pcap-nit.h pcap-pf.h \
 	ethertype.h gencode.h gnuc.h


### PR DESCRIPTION
Make couldn't complete succesfully on a fresh install of Ubuntu 22.04.  All dependencies were installed `apt install build-essential bison flex libpcap-dev libtirpc-dev` but make seemed to be having issues finding the rpc libraries:

```
root@host:~/argus-3.0.8.3/argus# gcc -O -I. -I/usr/include -I./../include -I/usr/include/tirpc/rpc -DHAVE_CONFIG_H  -o ../bin/argus argus.o ArgusModeler.o ArgusSource.o ArgusUtil.o ArgusOutput.o ArgusUdp.o ArgusTcp.o ArgusIcmp.o ArgusIgmp.o ArgusEsp.o ArgusArp.o ArgusFrag.o ArgusUdt.o ArgusLcp.o ArgusIsis.o ArgusAuth.o Argus802.11.o ArgusApp.o ArgusEvents.o ArgusNetflow.o ArgusSflow.o  -lpcap -lpthread -ltirpc -lm ../lib/argus_common.a -lm
/usr/bin/ld: ../lib/argus_common.a(argus_util.o): in function `ArgusHtoN':
argus_util.c:(.text+0x9b4): undefined reference to `xdrmem_create'
/usr/bin/ld: argus_util.c:(.text+0x9bf): undefined reference to `xdr_int'
/usr/bin/ld: argus_util.c:(.text+0x9cc): undefined reference to `xdr_float'
/usr/bin/ld: argus_util.c:(.text+0x9d9): undefined reference to `xdr_float'
/usr/bin/ld: argus_util.c:(.text+0x9e6): undefined reference to `xdr_float'
/usr/bin/ld: argus_util.c:(.text+0x9f3): undefined reference to `xdr_float'
collect2: error: ld returned 1 exit status
```

Upon investigation it seems that the ordering of -ltirpc and -lm ../lib/argus_common.a is siginificant, and flipping these from `-ltirpc -lm ../lib/argus_common.a` to `-lm ../lib/argus_common.a -ltirpc` would allow the build to complete succesfully.

This pull requests modifies `argus/Makefile.in` to make this ordering the default.  I haven't tried it against any other distributions to make sure this doesn't introduce breaking changes.